### PR TITLE
Fix Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#XSPFy
+# XSPFy
 
 Migrates XSPF playlists to Spotify where they can grow old.
 
@@ -16,13 +16,13 @@ https://github.com/kevlened/csvToXspf
 To export your Spotify playlists:  
 https://rawgit.com/watsonbox/exportify/master/exportify.html
 
-###Usage
+### Usage
 `python xspfy.py XSPF_PATH SPOTIFY_USERNAME`
 
-###Screenshot
+### Screenshot
 ![XSPFy screenshot](https://hostr.co/file/AsJX2zukaVkt/xspfy.png)
 
-###Installation
+### Installation
     pip install requests spotipy
     git clone https://github.com/sepehr/xspfy.git
     chmod +x ./xspfy/xspfy.py


### PR DESCRIPTION
GitHub's Markdown interpreter was changed to strictly enforce the GFM spec, which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information: 
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
github/markup#1013
